### PR TITLE
Update for Chrome 68 and ChromeDriver 2.39

### DIFF
--- a/driverVersions.json
+++ b/driverVersions.json
@@ -49,12 +49,16 @@
             "driverVersion": "2.36"
         },
         "66": {
-            "driverNPMPackageVersion": "2.38.3",
-            "driverVersion": "2.38"
+            "driverNPMPackageVersion": "2.39.0",
+            "driverVersion": "2.39"
         },
         "67": {
-            "driverNPMPackageVersion": "2.38.3",
-            "driverVersion": "2.38"
+            "driverNPMPackageVersion": "2.39.0",
+            "driverVersion": "2.39"
+        },
+        "68": {
+            "driverNPMPackageVersion": "2.39.0",
+            "driverVersion": "2.39"
         }
     },
     "geckoDriverVersions": {

--- a/driverVersions.json
+++ b/driverVersions.json
@@ -49,12 +49,12 @@
             "driverVersion": "2.36"
         },
         "66": {
-            "driverNPMPackageVersion": "2.39.0",
-            "driverVersion": "2.39"
+            "driverNPMPackageVersion": "2.38.3",
+            "driverVersion": "2.38"
         },
         "67": {
-            "driverNPMPackageVersion": "2.39.0",
-            "driverVersion": "2.39"
+            "driverNPMPackageVersion": "2.38.3",
+            "driverVersion": "2.38"
         },
         "68": {
             "driverNPMPackageVersion": "2.39.0",

--- a/package.json
+++ b/package.json
@@ -20,5 +20,5 @@
         "postinstall": "./postinstall",
         "test": "node_modules/mocha/bin/mocha *.spec.js"
     },
-    "version": "1.0.6"
+    "version": "1.0.7"
 }

--- a/postinstall
+++ b/postinstall
@@ -1,15 +1,15 @@
 #!/bin/bash
 
-if [[ (-n "${BROWSER_DRIVER_INSTALLER_CHROME_VERSION}") && (-n "${BROWSER_DRIVER_INSTALLER_CHROMEDRIVER_PATH}")]]; then
-    node ./index.js --browser-name chrome \
+if [[ -n "${BROWSER_DRIVER_INSTALLER_CHROME_VERSION:-}" && -n "${BROWSER_DRIVER_INSTALLER_CHROMEDRIVER_PATH:-}" ]]; then
+    node ./index.js --browser-name chrome                                        \
                     --browser-version "$BROWSER_DRIVER_INSTALLER_CHROME_VERSION" \
                     --target-path "$BROWSER_DRIVER_INSTALLER_CHROMEDRIVER_PATH"
 else 
     echo "Environment variables for Chrome are not set, skipping post-install for Chrome"
 fi
 
-if [[ (-n "${BROWSER_DRIVER_INSTALLER_FIREFOX_VERSION}") && (-n "${BROWSER_DRIVER_INSTALLER_GECKODRIVER_PATH}")]]; then
-    node ./index.js --browser-name firefox \
+if [[ -n "${BROWSER_DRIVER_INSTALLER_FIREFOX_VERSION:-}" && -n "${BROWSER_DRIVER_INSTALLER_GECKODRIVER_PATH:-}" ]]; then
+    node ./index.js --browser-name firefox                                        \
                     --browser-version "$BROWSER_DRIVER_INSTALLER_FIREFOX_VERSION" \
                     --target-path "$BROWSER_DRIVER_INSTALLER_GECKODRIVER_PATH"
 else 


### PR DESCRIPTION
The npm package for ChromeDriver 2.39 is not published yet at https://www.npmjs.com/package/chromedriver. The changes won't work until so.